### PR TITLE
Feature: Add semver functionality

### DIFF
--- a/cmd/change.go
+++ b/cmd/change.go
@@ -10,7 +10,7 @@ import (
 )
 
 func DoChange(change ChangeRequest) (result bool) {
-	r, stringContents := ReadFile(change.File)
+	r, stringContents := readFile(change.File)
 
 	var originalContents string
 

--- a/cmd/grep.go
+++ b/cmd/grep.go
@@ -224,14 +224,14 @@ func matchSemver(input string, semverConstraint string) bool {
 	c, err := semver.NewConstraint(semverConstraint)
 
 	if err != nil {
-		logger.Fatal("Bad semver constraint supplied")
+		logger.Warnf("Bad semver constraint '%s' supplied", semverConstraint)
 		return false
 	}
 
 	v, err := semver.NewVersion(input)
 
 	if err != nil {
-		logger.Warnf("Version %s is not a valid semver version", input)
+		logger.Warnf("Version '%s' is not a valid semver version", input)
 		return false
 	}
 

--- a/cmd/grep_test.go
+++ b/cmd/grep_test.go
@@ -1,1 +1,32 @@
 package cmd
+
+import (
+	"testing"
+
+	"github.com/digtux/laminar/pkg/logger"
+)
+
+func init() {
+	logger.InitLogger(true)
+}
+
+func TestMatchSemver(t *testing.T) {
+	semverTests := []struct {
+		version    string
+		constraint string
+		output     bool
+	}{
+		{version: "v0.0.1", constraint: "thisisfake", output: false},
+		{version: "thisisfake", constraint: ">=0.0.0", output: false},
+		{version: "v0.0.1", constraint: ">=0.0.0", output: true},
+		{version: "v0.0.1", constraint: ">=1.0.0", output: false},
+	}
+
+	for _, test := range semverTests {
+		s := matchSemver(test.version, test.constraint)
+		if s != test.output {
+			t.Errorf("testSemver(%s, %s), got: '%t' but expected: '%t'", test.version, test.constraint, s, test.output)
+		}
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v0.11.0 // indirect
 	cloud.google.com/go/longrunning v0.4.1 // indirect
+	github.com/Masterminds/semver v1.5.0
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/acomagu/bufpipe v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ cloud.google.com/go/iam v0.11.0/go.mod h1:9PiLDanza5D+oWFZiH1uG+RnRCfEGKoyl6yo4c
 cloud.google.com/go/longrunning v0.4.1 h1:v+yFJOfKC3yZdY6ZUI933pIYdhyhV8S3NpWrXWmg7jM=
 cloud.google.com/go/longrunning v0.4.1/go.mod h1:4iWDqhBZ70CvZ6BfETbvam3T8FMvLK+eFj0E6AaRQTo=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=

--- a/pkg/gitoperations/git.go
+++ b/pkg/gitoperations/git.go
@@ -38,8 +38,9 @@ func (c *Client) Pull(registry cfg.GitRepo) {
 		"branch", registry.Branch,
 	)
 	err = w.Pull(&git.PullOptions{
-		RemoteName: "origin",
-		Depth:      1,
+		RemoteName:    "origin",
+		Depth:         1,
+		ReferenceName: plumbing.NewBranchReferenceName(registry.Branch),
 	})
 	// TODO: replace with err.Error() and check if functions the same
 	if fmt.Sprintf("%v", err) == "already up-to-date" {
@@ -82,7 +83,7 @@ func (c *Client) InitialGitCloneAndCheckout(registry cfg.GitRepo) *git.Repositor
 			)
 		}
 	}
-	var mergeRef = plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", registry.Branch))
+	var branchRef = plumbing.NewBranchReferenceName(registry.Branch)
 
 	r, err := git.PlainClone(diskPath, false, &git.CloneOptions{
 		URL:           registry.URL,
@@ -90,7 +91,7 @@ func (c *Client) InitialGitCloneAndCheckout(registry cfg.GitRepo) *git.Repositor
 		Auth:          authMethod,
 		SingleBranch:  true,
 		NoCheckout:    false,
-		ReferenceName: mergeRef,
+		ReferenceName: branchRef,
 	})
 	if err != nil {
 		logger.Fatalw("unable to clone the git repo",
@@ -123,7 +124,7 @@ func (c *Client) InitialGitCloneAndCheckout(registry cfg.GitRepo) *git.Repositor
 	err = w.Checkout(&git.CheckoutOptions{
 		// Hash:  *rev,
 		// Force:  true,
-		Branch: mergeRef,
+		Branch: branchRef,
 	})
 
 	if err != nil {


### PR DESCRIPTION
Allow specifying a semver constraint in laminar config like this:
```
- pattern: "semver:>= 0.0.1"
  files:
  - path: /your/path/to/check/for/semvers
```

Any pattern supported by https://github.com/Masterminds/semver can be used.